### PR TITLE
Code cleanup and replace class_inheritable_accessor

### DIFF
--- a/lib/slugger.rb
+++ b/lib/slugger.rb
@@ -16,35 +16,40 @@ module Slugger
         :downcase          => true,
         :on_conflict       => :error
       }
-      # :on_conflict can be :error or :concat_random_chars
+
       self.slugger_options = default_options.merge(options)
       self.slugger_options[:title_column] = title_column unless title_column.nil?
 
-      # if columns_hash[slugger_options[:title_column].to_s].nil?
-      #   raise ArgumentError, "#{self.name} is missing source column"
-      # end
-      raise ArgumentError, "#{self.name} is missing required #{slugger_options[:slug_column]} column" if columns_hash[slugger_options[:slug_column].to_s].nil?
+      if columns_hash[slugger_options[:slug_column].to_s].nil?
+        raise ArgumentError, "#{self.name} is missing required " +
+                             "#{slugger_options[:slug_column]} column"
+      end
 
       before_validation :permalize, :on => :create
 
       validates slugger_options[:slug_column].to_sym, :presence => true
+
       if slugger_options[:scope]
-        validates slugger_options[:slug_column].to_sym, :uniqueness => {:scope => slugger_options[:scope]}
+        validates slugger_options[:slug_column].to_sym,
+                  :uniqueness => { :scope => slugger_options[:scope] }
       else
-        validates slugger_options[:slug_column].to_sym, :uniqueness => true
+        validates slugger_options[:slug_column].to_sym,
+                  :uniqueness => true
       end
 
-      send :define_method, :column_to_slug, lambda { self.send(slugger_options[:title_column]) }
+      send :define_method, :column_to_slug,
+        lambda { self.send(slugger_options[:title_column]) }
 
       include InstanceMethods
     end
   end
   module InstanceMethods
 
-    protected
+    private
 
     def permalize
       return unless self.send("#{self.slugger_options[:slug_column]}").blank?
+
       if slugger_options[:title_column].is_a?(Array)
         s = ""
         self.slugger_options[:title_column].each do |m|
@@ -52,34 +57,42 @@ module Slugger
         end
         s = Iconv.iconv('ascii//ignore//translit', 'utf-8', s).to_s
       else
-        s = Iconv.iconv('ascii//ignore//translit', 'utf-8', self.send("#{self.slugger_options[:title_column]}")).to_s
+        s = Iconv.iconv('ascii//ignore//translit', 'utf-8',
+              self.send("#{self.slugger_options[:title_column]}")).to_s
       end
-      s.gsub!(/\'/, '')   # remove '
-      s.gsub!(/\W+/, ' ') # all non-word chars to spaces
-      s.strip!            # ohh la la
-      s.downcase!         if slugger_options[:downcase]
-      s.gsub!(/\ +/, slugger_options[:substitution_char].to_s) # spaces to dashes, preferred separator char everywhere
+
+      # Remove apostrophes
+      s.gsub!(/\'/, '')
+      # Replace all non-word chars to spaces
+      s.gsub!(/\W+/, ' ')
+      s.strip!
+      # Replace spaces with dashes or custom substitution character
+      s.gsub!(/\ +/, slugger_options[:substitution_char].to_s)
+      s.downcase! if slugger_options[:downcase]
+
       self.send("#{self.slugger_options[:slug_column]}=", s)
+
       slug_conflict_resolution
     end
+
     def slug_conflict_resolution(append=nil)
-      existing = self.class.send(:where, "#{slugger_options[:slug_column]}".to_sym => self.send("#{self.slugger_options[:slug_column]}")).first
-      if existing
+      slug_column = slugger_options[:slug_column]
+
+      # Check if there are any records which the generated slug will conflict with
+      if self.class.where(slug_column => read_attribute(slug_column)).any?
         self.send("slug_conflict_resolution_#{self.slugger_options[:on_conflict]}", append)
       end
     end
+
     def slug_conflict_resolution_concat_random_chars(append)
       chars = ("a".."z").to_a + ("1".."9").to_a
       random_chars = Array.new(3, '').collect{chars[rand(chars.size)]}.join
       self.send("#{self.slugger_options[:slug_column]}=", "#{self.slugger_options[:slug_column]}#{self.slugger_options[:substitution_char]}#{random_chars}")
       slug_conflict_resolution
     end
-    def slug_conflict_resolution_error(append)
-      # no op, validatino sets error
-    end
 
-    def strip_title
-      self.send("#{self.slugger_options[:title_column]}").strip!
+    def slug_conflict_resolution_error(append)
+      # no op, validation sets error
     end
   end
 end

--- a/lib/slugger.rb
+++ b/lib/slugger.rb
@@ -8,7 +8,7 @@ module Slugger
   end
   module ClassMethods
     def has_slug(title_column=nil,options={})
-      class_inheritable_accessor :slugger_options
+      class_attribute :slugger_options
       default_options = {
         :title_column      => 'title',
         :slug_column       => 'slug',
@@ -19,7 +19,7 @@ module Slugger
       # :on_conflict can be :error or :concat_random_chars
       self.slugger_options = default_options.merge(options)
       self.slugger_options[:title_column] = title_column unless title_column.nil?
-      
+
       # if columns_hash[slugger_options[:title_column].to_s].nil?
       #   raise ArgumentError, "#{self.name} is missing source column"
       # end
@@ -35,7 +35,7 @@ module Slugger
       end
 
       send :define_method, :column_to_slug, lambda { self.send(slugger_options[:title_column]) }
-    
+
       include InstanceMethods
     end
   end


### PR DESCRIPTION
Hey Seth,

Thanks for writing this gem. I found most of the other slug generating gems out there are either unmaintained or overkill for my needs. Slugger did almost everything I needed it to do, and nothing more. I did however run into a few problems using this with Rails 3.1+, as `class_inheritable_accessor` is deprecated and removed from Rails 3.1

So one commit fixes that, and the other includes some very small code style changes: Wrapping to 80 characters per column, replacing `#send` where we don't need to use it, etc.

I also have two more pull requests which I will send over. One adds a `max_length` param which will limit the length of the generated slug. The other adds a new conflict resolution method by appending the database ID to slugs which conflict. I had to do some hand-wavy stuff to get that working, so you can make a judgement call if you want to merge it.

The reason I've submitted this one first is that the others built on top of the cleanup I did here. So if you don't like this patch then we probably won't be able to easily merge in those other features :flushed:

Let me know if there is anything here you'd like to see changed. And again thanks for releasing this project!

Jordan
