### PR TITLE
Clip slugs when max_length is set

### DIFF
--- a/lib/slugger.rb
+++ b/lib/slugger.rb
@@ -69,6 +69,7 @@ module Slugger
       # Replace spaces with dashes or custom substitution character
       s.gsub!(/\ +/, slugger_options[:substitution_char].to_s)
       s.downcase! if slugger_options[:downcase]
+      s = s[0..(slugger_options[:max_length] - 1)] if slugger_options[:max_length]
 
       self.send("#{self.slugger_options[:slug_column]}=", s)
 

--- a/spec/lib/post_spec.rb
+++ b/spec/lib/post_spec.rb
@@ -13,6 +13,11 @@ describe Post do
     p = Post.create(:title => "apostrop'hes", :slug => "apostrophes")
     p.slug.should == "apostrophes"
   end
+  it "should be limited to 20 characters" do
+    p = Post.create(
+      :title => "when you write really long titles slugs should be shortened")
+    p.slug.should == "when-you-write-reall"
+  end
   it "should not be valid on duplicate" do
     p = Post.create(:title => "hello")
     p.slug.should == "hello"

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -13,14 +13,14 @@ class CreateSchema < ActiveRecord::Migration
       t.string :slug
       t.timestamps
     end
-    
+
     create_table :users, :force => true do |t|
       t.string :first_name
       t.string :last_name
       t.string :slug
       t.timestamps
     end
-    
+
     create_table :edges, :force => true do |t|
       t.string :name
       t.string :slug_name
@@ -33,7 +33,7 @@ CreateSchema.suppress_messages do
 end
 
 class Post < ActiveRecord::Base
-  has_slug
+  has_slug 'title', :max_length => 20
 end
 
 class User < ActiveRecord::Base


### PR DESCRIPTION
A discussed in my first pull request: Adds a max_length param which will limit the length of the generated slug
