### PR TITLE
Add append_id conflict resolution

### DIFF
--- a/lib/slugger.rb
+++ b/lib/slugger.rb
@@ -27,6 +27,9 @@ module Slugger
 
       before_validation :permalize, :on => :create
 
+      # Used by +slug_conflict_resolution_append_id+
+      after_create      :append_id_to_slug
+
       validates slugger_options[:slug_column].to_sym, :presence => true
 
       if slugger_options[:scope]
@@ -91,8 +94,24 @@ module Slugger
       slug_conflict_resolution
     end
 
+    def slug_conflict_resolution_append_id(append)
+      slug_column       = slugger_options[:slug_column]
+      substitution_char = slugger_options[:substitution_char]
+
+      # Temporarily write the slug with '+ID+' appended, then update the slug
+      # after the record is saved to the database +appended_id_to_slug+
+      self[slug_column] = [self[slug_column], '+ID+'].join(substitution_char)
+    end
+
     def slug_conflict_resolution_error(append)
       # no op, validation sets error
+    end
+
+    def append_id_to_slug
+      slug_column = slugger_options[:slug_column]
+      id_regex    = /\+ID\+\z/
+      return unless self[slug_column][id_regex]
+      update_attribute(slug_column, self[slug_column].gsub(id_regex, id.to_s))
     end
   end
 end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -9,4 +9,11 @@ describe User do
     u = User.create(:first_name => "Tyler", :last_name => "Durden")
     u.slug.should == "tyler-durden"
   end
+  it "should append the database id if duplicates exist" do
+    first_user = User.create(:first_name => "Jordan", :last_name => "Byron")
+    first_user.slug.should == "jordan-byron"
+
+    second_user = User.create(:first_name => "Jordan", :last_name => "Byron")
+    second_user.slug.should == "jordan-byron-#{second_user.id}"
+  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -13,14 +13,14 @@ class CreateSchema < ActiveRecord::Migration
       t.string :slug
       t.timestamps
     end
-    
+
     create_table :users, :force => true do |t|
       t.string :first_name
       t.string :last_name
       t.string :slug
       t.timestamps
     end
-    
+
     create_table :edges, :force => true do |t|
       t.string :name
       t.string :slug_name
@@ -37,7 +37,7 @@ class Post < ActiveRecord::Base
 end
 
 class User < ActiveRecord::Base
-  has_slug [:first_name, :last_name]
+  has_slug [:first_name, :last_name], :on_conflict => :append_id
 end
 
 class Edge < ActiveRecord::Base


### PR DESCRIPTION
Adds a new conflict resolution method by appending the database ID to slugs which conflict. 

As I mentioned before, I'm not crazy about this patch, but it seems to work. I'm open to discussing alternative methods which accomplish the same thing.

I do agree with you that this probably shouldn't be the default conflict resolution. Having the standard rails validation error is probably the right choice.
