### PR TITLE
Remove duplicate after_create from bad merge

### DIFF
--- a/lib/slugger.rb
+++ b/lib/slugger.rb
@@ -31,9 +31,6 @@ module Slugger
       # Used by +slug_conflict_resolution_append_id+
       after_create      :append_id_to_slug
 
-      # Used by +slug_conflict_resolution_append_id+
-      after_create      :append_id_to_slug
-
       validates slugger_options[:slug_column].to_sym, :presence => true
 
       if slugger_options[:scope]


### PR DESCRIPTION
It's me again! I just noticed the `after_create` callback was duplicated in my last pull request. Sorry about that. This removes the duplicate line.
