### PR TITLE
Slugs should never end with a substitution character

### DIFF
--- a/lib/slugger.rb
+++ b/lib/slugger.rb
@@ -73,7 +73,11 @@ module Slugger
       # Replace spaces with dashes or custom substitution character
       s.gsub!(/\ +/, slugger_options[:substitution_char].to_s)
       s.downcase! if slugger_options[:downcase]
-      s = s[0..(slugger_options[:max_length] - 1)] if slugger_options[:max_length]
+
+      if slugger_options[:max_length]
+        s = s[0..(slugger_options[:max_length] - 1)]
+        s = s[0..-2] if s[-1] == slugger_options[:substitution_char].to_s
+      end
 
       self.send("#{self.slugger_options[:slug_column]}=", s)
 

--- a/spec/lib/post_spec.rb
+++ b/spec/lib/post_spec.rb
@@ -13,10 +13,15 @@ describe Post do
     p = Post.create(:title => "apostrop'hes", :slug => "apostrophes")
     p.slug.should == "apostrophes"
   end
-  it "should be limited to 20 characters" do
+  it "slug should be limited to 20 characters" do
     p = Post.create(
       :title => "when you write really long titles slugs should be shortened")
     p.slug.should == "when-you-write-reall"
+  end
+  it "slug should not end with a substitution character" do
+    p = Post.create(
+      :title => "when you write very long titles slugs should be shortened")
+    p.slug.should == "when-you-write-very"
   end
   it "should not be valid on duplicate" do
     p = Post.create(:title => "hello")


### PR DESCRIPTION
Currently it is possible for generated slugs to end with a substitution character when `max_length` is set. That results in nasty looking slugs, and eventually urls. This tiny patch ensures any trailing substitution characters are removed.
